### PR TITLE
Modify 'server info' to show update diff & current bots playing

### DIFF
--- a/src/game/Chat/Level0.cpp
+++ b/src/game/Chat/Level0.cpp
@@ -30,6 +30,11 @@
 #include "revision.h"
 #include "Util/Util.h"
 
+#ifdef ENABLE_PLAYERBOTS
+#include "playerbot.h"
+#include "RandomPlayerbotMgr.h"
+#endif
+
 bool ChatHandler::HandleHelpCommand(char* args)
 {
     if (!*args)
@@ -104,6 +109,10 @@ bool ChatHandler::HandleServerInfoCommand(char* /*args*/)
     PSendSysMessage(LANG_USING_WORLD_DB, sWorld.GetDBVersion());
     PSendSysMessage(LANG_USING_EVENT_AI, sWorld.GetCreatureEventAIVersion());
     PSendSysMessage(LANG_CONNECTED_USERS, activeClientsNum, maxActiveClientsNum, queuedClientsNum, maxQueuedClientsNum);
+    #ifdef ENABLE_PLAYERBOTS
+    PSendSysMessage("Online bots: %lu (MaxRandomBots: %lu)", sRandomPlayerbotMgr.playerBots.size(), sRandomPlayerbotMgr.GetMaxAllowedBotCount());
+    #endif
+    PSendSysMessage("Current diff: %lu | Average diff: %lu | Maximum diff: %lu", sWorld.GetCurrentDiff(), sWorld.GetAverageDiff(), sWorld.GetMaxDiff());
     PSendSysMessage(LANG_UPTIME, str.c_str());
 
     return true;


### PR DESCRIPTION
## 🍰 Pullrequest
Modify the command '.server info' to show update diff & bots playing, it's useful to monitor the worldserver health in-game, without needing to ssh/rdp/remote into your server.

### Proof
![image](https://user-images.githubusercontent.com/7340774/228737034-fe0873ff-e941-426e-a7ef-8545c002a761.png)
![image](https://user-images.githubusercontent.com/7340774/228737890-c34a0ad8-c823-4791-9a6e-cba985640858.png)


### Issues
- None

### How2Test
- See checklist, for successful compile
- run command .server info

### Todo / Checklist
#ifdef ENABLE_PLAYERBOTS in CMake, requires change in:

[PlayerbotMgr.h](https://github.com/celguar/mangosbot-bots/blob/master/playerbot/PlayerbotMgr.h)

```
protected:
    PlayerBotMap playerBots;
};
```

to:

```
public:
    PlayerBotMap playerBots;
};
```