### PR TITLE
 Revert Corechanges to make bots see gameobjects

### DIFF
--- a/src/game/vmap/GameObjectModel.cpp
+++ b/src/game/vmap/GameObjectModel.cpp
@@ -93,6 +93,9 @@ bool GameObjectModel::initialize(const GameObject* const pGo, const GameObjectDi
     if (!iModel)
         return false;
 
+    if (it->second.name.find(".m2") != std::string::npos)
+        iModel->setModelFlags(VMAP::MOD_M2);
+
     name = it->second.name;
     iPos = Vector3(pGo->GetPositionX(), pGo->GetPositionY(), pGo->GetPositionZ());
     collision_enabled = true;


### PR DESCRIPTION

Reverted core update since bots have issues seeing certen gameobjects.